### PR TITLE
Update part name for zcu104.toml, reset port_width

### DIFF
--- a/examples/platforms/zcu104.toml
+++ b/examples/platforms/zcu104.toml
@@ -1,7 +1,7 @@
 [device]
 name = "zcu104"
 #family = ""
-part = "xczu7ev-ffvb1156-2-e"
+part = "xczu7ev-ffvc1156-2-e"
 board = "" #TODO: add board file
 
 [resources]

--- a/fpgaconvnet/optimiser/solvers/solver.py
+++ b/fpgaconvnet/optimiser/solvers/solver.py
@@ -382,7 +382,16 @@ class Solver:
         if not self.constrain_port_width:
             return
 
-        port_width = self.platform.eth_port_width if self.multi_fpga else self.platform.port_width
+        # port_width = self.platform.eth_port_width if self.multi_fpga else self.platform.port_width
+        # force port_width = 64 for now
+        if self.multi_fpga:
+            port_width = self.platform.eth_port_width
+        else: 
+            if (self.net.backend == "hls"):
+                port_width = 64
+            else: port_width = self.platform.port_width 
+
+
         for partition in self.net.partitions:
             ## remove auxiliary layers
             partition.remove_squeeze()


### PR DESCRIPTION
Update part name for zcu104.toml, the part name should be "xczu7ev-ffvc1156-2-e". This update is also suitable for other branches. The `port_width` is also reset to 64 to temporarily make restrict the bit number in the stream. 