### PR TITLE
Update solver.py, allow passing port_width

### DIFF
--- a/fpgaconvnet/optimiser/solvers/solver.py
+++ b/fpgaconvnet/optimiser/solvers/solver.py
@@ -382,14 +382,14 @@ class Solver:
         if not self.constrain_port_width:
             return
 
-        # port_width = self.platform.eth_port_width if self.multi_fpga else self.platform.port_width
+        port_width = self.platform.eth_port_width if self.multi_fpga else self.platform.port_width
         # force port_width = 64 for now
-        if self.multi_fpga:
-            port_width = self.platform.eth_port_width
-        else: 
-            if (self.net.backend == "hls"):
-                port_width = 64
-            else: port_width = self.platform.port_width 
+        # if self.multi_fpga:
+        #     port_width = self.platform.eth_port_width
+        # else: 
+        #     if (self.net.backend == "hls"):
+        #         port_width = 64
+        #     else: port_width = self.platform.port_width 
 
 
         for partition in self.net.partitions:


### PR DESCRIPTION
Remove the restriction of setting `port_width` = 64 bits, allow passing `port_width` from platform information. 